### PR TITLE
If a hidden field did not have the variable 'value' set as well, we were...

### DIFF
--- a/src/RobinMalfait/Formgenerator/Formgenerator.php
+++ b/src/RobinMalfait/Formgenerator/Formgenerator.php
@@ -63,7 +63,10 @@ class Formgenerator{
                         if ($this->getContentBefore($fieldName))
                             $data[] = $this->getContentBefore($fieldName);
 
-                        $data[] = $this->form->input($type, $fieldName, $this->getSettings('types', $fieldName, 'value'), $extras);
+                        if ($this->getSettings('types', $fieldName, 'value'))
+                            $data[] = $this->form->input($type, $fieldName, $this->getSettings('types', $fieldName, 'value'), $extras);
+                        else
+                            $data[] = $this->form->input($type, $fieldName, null, $extras);
 
                         if ($this->getContentAfter($fieldName))
                             $data[] = $this->getContentAfter($fieldName);


### PR DESCRIPTION
... getting an htmlentities error. This has been fixed so this value can now be unset. Obviously this was needed for events such as DOM modifiers on hidden fields.

This also brings in values automatically based on existing framework and now "value" is more of an override.
