### PR TITLE
allow all illuminate/support versions starting with 4.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     ],
     "require": {
         "php": ">=5.3.0",
-        "illuminate/support": "4.0.x"
+        "illuminate/support": "4.x"
     },
     "autoload": {
         "psr-0": {


### PR DESCRIPTION
I updated composer.json so it can work with illuminate/support 4.1
